### PR TITLE
Fix yfinance JSON serialization bug - preserve pandas Timestamp data in ETL pipeline

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 # Import pandas for timestamp handling if available
 try:
     import pandas as pd
+
     PANDAS_AVAILABLE = True
 except ImportError:
     PANDAS_AVAILABLE = False
@@ -56,30 +57,26 @@ def sanitize_data(obj, logger):
                     try:
                         # Convert pandas Timestamp to ISO format string
                         new_key = k.isoformat()
-                        logger.debug(
-                            f"Converted pandas Timestamp key {k} to ISO format: {new_key}"
-                        )
+                        logger.debug(f"Converted pandas Timestamp key {k} to ISO format: {new_key}")
                         new_dict[new_key] = sanitize_data(v, logger)
                         continue
                     except Exception as e:
                         logger.warning(
                             f"Failed to convert pandas Timestamp key {k} to ISO format: {e}. Using string representation."
                         )
-                
+
                 # Special handling for datetime objects
                 elif isinstance(k, datetime):
                     try:
                         new_key = k.isoformat()
-                        logger.debug(
-                            f"Converted datetime key {k} to ISO format: {new_key}"
-                        )
+                        logger.debug(f"Converted datetime key {k} to ISO format: {new_key}")
                         new_dict[new_key] = sanitize_data(v, logger)
                         continue
                     except Exception as e:
                         logger.warning(
                             f"Failed to convert datetime key {k} to ISO format: {e}. Using string representation."
                         )
-                
+
                 # For other unsupported key types, convert to string but preserve the value
                 logger.info(
                     f"Key {k} (type {type(k)}) is not a native JSON key type; converting to string while preserving value"

--- a/common/utils.py
+++ b/common/utils.py
@@ -3,6 +3,13 @@ import re
 import warnings
 from datetime import datetime, timedelta
 
+# Import pandas for timestamp handling if available
+try:
+    import pandas as pd
+    PANDAS_AVAILABLE = True
+except ImportError:
+    PANDAS_AVAILABLE = False
+
 
 def suppress_third_party_logs():
     """
@@ -37,17 +44,48 @@ def sanitize_data(obj, logger):
     """
     Recursively traverse the object.
     For any dictionary key that is not of type str, int, float, bool, or None,
-    log a warning and convert that key to a string and set its value to None.
+    convert it to a JSON-serializable format while preserving the data.
+    Special handling for pandas Timestamp and datetime objects to preserve temporal data.
     """
     if isinstance(obj, dict):
         new_dict = {}
         for k, v in obj.items():
             if not isinstance(k, (str, int, float, bool)) and k is not None:
-                logger.warning(
-                    f"Key {k} (type {type(k)}) is not a valid JSON key type; converting key to string and setting its value to null"
+                # Special handling for pandas Timestamp objects
+                if PANDAS_AVAILABLE and isinstance(k, pd.Timestamp):
+                    try:
+                        # Convert pandas Timestamp to ISO format string
+                        new_key = k.isoformat()
+                        logger.debug(
+                            f"Converted pandas Timestamp key {k} to ISO format: {new_key}"
+                        )
+                        new_dict[new_key] = sanitize_data(v, logger)
+                        continue
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to convert pandas Timestamp key {k} to ISO format: {e}. Using string representation."
+                        )
+                
+                # Special handling for datetime objects
+                elif isinstance(k, datetime):
+                    try:
+                        new_key = k.isoformat()
+                        logger.debug(
+                            f"Converted datetime key {k} to ISO format: {new_key}"
+                        )
+                        new_dict[new_key] = sanitize_data(v, logger)
+                        continue
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to convert datetime key {k} to ISO format: {e}. Using string representation."
+                        )
+                
+                # For other unsupported key types, convert to string but preserve the value
+                logger.info(
+                    f"Key {k} (type {type(k)}) is not a native JSON key type; converting to string while preserving value"
                 )
                 new_key = str(k)
-                new_dict[new_key] = None  # Discard the value by setting it to null
+                new_dict[new_key] = sanitize_data(v, logger)
             else:
                 new_key = k
                 new_dict[new_key] = sanitize_data(v, logger)
@@ -55,7 +93,19 @@ def sanitize_data(obj, logger):
     elif isinstance(obj, list):
         return [sanitize_data(item, logger) for item in obj]
     else:
-        return obj
+        # Handle pandas Timestamp and datetime objects in values as well
+        if PANDAS_AVAILABLE and isinstance(obj, pd.Timestamp):
+            try:
+                return obj.isoformat()
+            except Exception:
+                return str(obj)
+        elif isinstance(obj, datetime):
+            try:
+                return obj.isoformat()
+            except Exception:
+                return str(obj)
+        else:
+            return obj
 
 
 def get_project_paths():


### PR DESCRIPTION
## Summary

Fix yfinance JSON serialization bug - preserve pandas Timestamp data in ETL pipeline

## Key Changes

- **Common/Shared**: Updated 1 files

## Files Changed

common/utils.py | 57 ++++++++++++++++++++++++++++++++++++++++++++++++++++-----
 1 file changed, 52 insertions(+), 5 deletions(-)

## Test Results

✅ **F2 Fast-Build Test**: PASSED (Fast 2 companies with DeepSeek 1.5b)
- 28 data files validated
- Test completed at 2025-08-27T04:32:05Z
- Build tracking verified

## Commits

- Fix yfinance JSON serialization bug - preserve pandas Timestamp data in ETL pipeline
- Format code with black and isort

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)